### PR TITLE
Fixes wrong Download URLs (German versions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ I will provide some helpful tools too.
 Version | Language | Download | Release date
 --- | --- | --- | ---
 1.08 | English | [zip](https://github.com/Pyrdacor/Ambermoon/raw/master/Disks/English/ambermoon_english_1.08_extracted.zip) [lha](https://github.com/Pyrdacor/Ambermoon/raw/master/Disks/English/ambermoon_english_1.08_extracted.lha) | 03-07-2021
-1.07 | German | [zip](https://github.com/Pyrdacor/Ambermoon/raw/master/Disks/English/ambermoon_german_1.07_extracted.zip) [lha](https://github.com/Pyrdacor/Ambermoon/raw/master/Disks/English/ambermoon_german_1.07_extracted.lha) | 03-07-2021
+1.07 | German | [zip](https://github.com/Pyrdacor/Ambermoon/raw/master/Disks/German/ambermoon_german_1.07_extracted.zip) [lha](https://github.com/Pyrdacor/Ambermoon/raw/master/Disks/German/ambermoon_german_1.07_extracted.lha) | 03-07-2021
 
 ### Patches
 


### PR DESCRIPTION
hi Pyrdacor,

the URLs for the German versions are wrong.
only a typo.

greetings